### PR TITLE
fix: Extra space in even month view

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ def main(
     # x, y for event description.
     daily_day_event = (
         toolbar + grid_start[0] + (5.5 * 3.5),
-        toolbar + grid_start[1] + 5.5 - 1.8
+        grid_start[1] + 5.5 - 1.8
     )
 
     # x, y for separator line in header


### PR DESCRIPTION
Fixes extra space in event month view caused by improper use of the toolbar variable.